### PR TITLE
Update default code setup.

### DIFF
--- a/frontend/src/views/Game.tsx
+++ b/frontend/src/views/Game.tsx
@@ -116,7 +116,7 @@ function GamePage() {
   const [players, setPlayers] = useState<Player[]>([]);
   const [gameTimer, setGameTimer] = useState<GameTimer | null>(null);
   const [problems, setProblems] = useState<Problem[]>([]);
-  const [currentLanguage, setCurrentLanguage] = useState<Language>(Language.Python);
+  const [currentLanguage, setCurrentLanguage] = useState<Language>(Language.Java);
   const [currentCode, setCurrentCode] = useState('');
   const [timeUp, setTimeUp] = useState(false);
   const [allSolved, setAllSolved] = useState(false);
@@ -256,9 +256,9 @@ function GamePage() {
             }
           });
 
-          // If no previous code, proceed as normal with the default Python language
+          // If no previous code, proceed as normal with the default Java language
           if (!matchFound) {
-            setDefaultCodeFromProblems(res.problems, '', Language.Python);
+            setDefaultCodeFromProblems(res.problems, '', Language.Java);
           }
         })
         .catch((err) => {

--- a/src/main/java/com/codejoust/main/service/generators/PythonDefaultCodeGeneratorService.java
+++ b/src/main/java/com/codejoust/main/service/generators/PythonDefaultCodeGeneratorService.java
@@ -61,15 +61,15 @@ public class PythonDefaultCodeGeneratorService implements DefaultCodeGeneratorSe
             case BOOLEAN:
                 return "bool";
             case ARRAY_STRING:
-                return "List[str]";
+                return "list[str]";
             case ARRAY_INTEGER:
-                return "List[int]";
+                return "list[int]";
             case ARRAY_DOUBLE:
-                return "List[float]";
+                return "list[float]";
             case ARRAY_CHARACTER:
-                return "List[str]";
+                return "list[str]";
             case ARRAY_BOOLEAN:
-                return "List[bool]";
+                return "list[bool]";
             default:
                 throw new ApiException(ProblemError.BAD_IOTYPE);
         }

--- a/src/main/java/com/codejoust/main/service/generators/PythonDefaultCodeGeneratorService.java
+++ b/src/main/java/com/codejoust/main/service/generators/PythonDefaultCodeGeneratorService.java
@@ -25,11 +25,13 @@ public class PythonDefaultCodeGeneratorService implements DefaultCodeGeneratorSe
             methodLineBuilder.append(
                 String.format(", %s: %s", 
                     problemInput.getName(),
-                    typeInstantiationToString(outputType)
+                    typeInstantiationToString(problemInput.getType())
                 )
             );
         }
-        methodLineBuilder.append("):");
+
+        // Add output type hinting.
+        methodLineBuilder.append(String.format(") -> %s:", typeInstantiationToString(outputType)));
 
         return String.join("\n",
             "class Solution:",

--- a/src/main/java/com/codejoust/main/service/generators/PythonDefaultCodeGeneratorService.java
+++ b/src/main/java/com/codejoust/main/service/generators/PythonDefaultCodeGeneratorService.java
@@ -27,8 +27,12 @@ public class PythonDefaultCodeGeneratorService implements DefaultCodeGeneratorSe
         }
         methodLineBuilder.append("):");
 
+        // Add a method header comment to describe the return type.
+        String returnComment = String.format("\t# The solve method should return the type %s", outputType.getClassType().getSimpleName());
+
         return String.join("\n",
             "class Solution(object):",
+            returnComment,
             methodLineBuilder.toString(),
             "\t\t"
         );

--- a/src/main/java/com/codejoust/main/service/generators/PythonDefaultCodeGeneratorService.java
+++ b/src/main/java/com/codejoust/main/service/generators/PythonDefaultCodeGeneratorService.java
@@ -33,8 +33,10 @@ public class PythonDefaultCodeGeneratorService implements DefaultCodeGeneratorSe
         // Add output type hinting.
         methodLineBuilder.append(String.format(") -> %s:", typeInstantiationToString(outputType)));
 
+        // Return the name with extra line to prevent frontend overlap.
         return String.join("\n",
             "class Solution:",
+            "",
             methodLineBuilder.toString(),
             "\t\t"
         );

--- a/src/test/java/com/codejoust/main/api/ProblemTests.java
+++ b/src/test/java/com/codejoust/main/api/ProblemTests.java
@@ -69,9 +69,8 @@ class ProblemTests {
     ).replaceAll("\t", "    ");
 
     public static final String pythonDefaultCode = String.join("\n",
-        "class Solution(object):",
-        "\t# The solve method should return the type Integer[]",
-        "\tdef solve(nums):",
+        "class Solution:",
+        "\tdef solve(self, nums: List[int]):",
         "\t\t"
     ).replaceAll("\t", "    ");
 

--- a/src/test/java/com/codejoust/main/api/ProblemTests.java
+++ b/src/test/java/com/codejoust/main/api/ProblemTests.java
@@ -70,6 +70,7 @@ class ProblemTests {
 
     public static final String pythonDefaultCode = String.join("\n",
         "class Solution(object):",
+        "\t# The solve method should return the type Integer[]",
         "\tdef solve(nums):",
         "\t\t"
     ).replaceAll("\t", "    ");

--- a/src/test/java/com/codejoust/main/api/ProblemTests.java
+++ b/src/test/java/com/codejoust/main/api/ProblemTests.java
@@ -70,6 +70,7 @@ class ProblemTests {
 
     public static final String pythonDefaultCode = String.join("\n",
         "class Solution:",
+        "",
         "\tdef solve(self, nums: List[int]) -> List[int]:",
         "\t\t"
     ).replaceAll("\t", "    ");

--- a/src/test/java/com/codejoust/main/api/ProblemTests.java
+++ b/src/test/java/com/codejoust/main/api/ProblemTests.java
@@ -71,7 +71,7 @@ class ProblemTests {
     public static final String pythonDefaultCode = String.join("\n",
         "class Solution:",
         "",
-        "\tdef solve(self, nums: List[int]) -> List[int]:",
+        "\tdef solve(self, nums: list[int]) -> list[int]:",
         "\t\t"
     ).replaceAll("\t", "    ");
 

--- a/src/test/java/com/codejoust/main/api/ProblemTests.java
+++ b/src/test/java/com/codejoust/main/api/ProblemTests.java
@@ -70,7 +70,7 @@ class ProblemTests {
 
     public static final String pythonDefaultCode = String.join("\n",
         "class Solution:",
-        "\tdef solve(self, nums: List[int]):",
+        "\tdef solve(self, nums: List[int]) -> List[int]:",
         "\t\t"
     ).replaceAll("\t", "    ");
 

--- a/src/test/java/com/codejoust/main/service/generators/DefaultCodeGeneratorServiceTests.java
+++ b/src/test/java/com/codejoust/main/service/generators/DefaultCodeGeneratorServiceTests.java
@@ -38,6 +38,7 @@ public class DefaultCodeGeneratorServiceTests {
 
     public static final String pythonDefaultCode = String.join("\n",
         "class Solution:",
+        "",
         "\tdef solve(self, nums: List[int]) -> List[int]:",
         "\t\t"
     );

--- a/src/test/java/com/codejoust/main/service/generators/DefaultCodeGeneratorServiceTests.java
+++ b/src/test/java/com/codejoust/main/service/generators/DefaultCodeGeneratorServiceTests.java
@@ -37,9 +37,8 @@ public class DefaultCodeGeneratorServiceTests {
     );
 
     public static final String pythonDefaultCode = String.join("\n",
-        "class Solution(object):",
-        "\t# The solve method should return the type Integer[]",
-        "\tdef solve(nums):",
+        "class Solution:",
+        "\tdef solve(self, nums: List[int]):",
         "\t\t"
     );
 

--- a/src/test/java/com/codejoust/main/service/generators/DefaultCodeGeneratorServiceTests.java
+++ b/src/test/java/com/codejoust/main/service/generators/DefaultCodeGeneratorServiceTests.java
@@ -38,6 +38,7 @@ public class DefaultCodeGeneratorServiceTests {
 
     public static final String pythonDefaultCode = String.join("\n",
         "class Solution(object):",
+        "\t# The solve method should return the type Integer[]",
         "\tdef solve(nums):",
         "\t\t"
     );

--- a/src/test/java/com/codejoust/main/service/generators/DefaultCodeGeneratorServiceTests.java
+++ b/src/test/java/com/codejoust/main/service/generators/DefaultCodeGeneratorServiceTests.java
@@ -38,7 +38,7 @@ public class DefaultCodeGeneratorServiceTests {
 
     public static final String pythonDefaultCode = String.join("\n",
         "class Solution:",
-        "\tdef solve(self, nums: List[int]):",
+        "\tdef solve(self, nums: List[int]) -> List[int]:",
         "\t\t"
     );
 

--- a/src/test/java/com/codejoust/main/service/generators/DefaultCodeGeneratorServiceTests.java
+++ b/src/test/java/com/codejoust/main/service/generators/DefaultCodeGeneratorServiceTests.java
@@ -39,7 +39,7 @@ public class DefaultCodeGeneratorServiceTests {
     public static final String pythonDefaultCode = String.join("\n",
         "class Solution:",
         "",
-        "\tdef solve(self, nums: List[int]) -> List[int]:",
+        "\tdef solve(self, nums: list[int]) -> list[int]:",
         "\t\t"
     );
 


### PR DESCRIPTION
### List of Changes:
- Change the default code to `Java`.
- Update Python code to use an instance method and include type hinting with `typeInstantiationToString`.
- Update relevant tests for Python default code.

### Notes:
- This PR requires the merge of [tester #22](https://github.com/CodeJoustHQ/tester/pull/22) to function properly, as described in [this discussion](https://github.com/CodeJoustHQ/main/pull/148#discussion_r624234885).
  - If you want to run this locally, you have to point the run code call to a local instance of tester that has the changes in the PR referenced above.
- An extra line was included for the Python default code to prevent the language selector on the frontend from overlapping with an extra-long method line.

### Screencast and Images:

[Screencast of New Python Default Code](https://www.loom.com/share/ab67abedd46547d4a7fd581f72a59b40)

**Python Default Code Type Hinting**
<img width="1248" alt="Python Default Code Type Hinting" src="https://user-images.githubusercontent.com/7987279/116765647-044cb500-a9db-11eb-9df2-a52257bbd3ba.png">
