### PR TITLE
use Submissions while reloading changes, and other minor fixes

### DIFF
--- a/frontend/src/api/Game.ts
+++ b/frontend/src/api/Game.ts
@@ -8,8 +8,6 @@ import { Color } from './Color';
 
 export type Player = {
   user: User,
-  code: string,
-  language: string,
   submissions: Submission[],
   solved: boolean,
   color: Color,
@@ -36,12 +34,14 @@ export type RunSolutionParams = {
   initiator: User,
   input: string,
   code: string,
+  problemIndex: number,
   language: string,
 };
 
 export type SubmitSolutionParams = {
   initiator: User,
   code: string,
+  problemIndex: number,
   language: string,
 };
 
@@ -63,6 +63,7 @@ export enum SubmissionType {
 
 export type Submission = {
   code: string,
+  problemIndex: number,
   language: string,
   results: SubmissionResult[],
   numCorrect: number,

--- a/frontend/src/views/Game.tsx
+++ b/frontend/src/views/Game.tsx
@@ -116,10 +116,10 @@ function GamePage() {
   const [players, setPlayers] = useState<Player[]>([]);
   const [gameTimer, setGameTimer] = useState<GameTimer | null>(null);
   const [problems, setProblems] = useState<Problem[]>([]);
-  const [languageList, setLanguageList] = useState<Language[]>([Language.Python]);
+  const [languageList, setLanguageList] = useState<Language[]>([Language.Java]);
   const [codeList, setCodeList] = useState<string[]>(['']);
   const [currentSubmission, setCurrentSubmission] = useState<Submission | null>(null);
-  const [currentProblem, setCurrentProblem] = useState<number>(0);
+  const [currentProblemIndex, setCurrentProblem] = useState<number>(0);
   const [timeUp, setTimeUp] = useState(false);
   const [allSolved, setAllSolved] = useState(false);
   const [defaultCodeList, setDefaultCodeList] = useState<DefaultCodeType[]>([]);
@@ -152,7 +152,7 @@ function GamePage() {
 
   const createCodeLanguageArray = () => {
     while (languageList.length < problems.length) {
-      languageList.push(Language.Python);
+      languageList.push(Language.Java);
     }
 
     while (codeList.length < problems.length) {
@@ -163,13 +163,14 @@ function GamePage() {
   createCodeLanguageArray();
 
   const setOneCurrentLanguage = (newLanguage: Language) => {
-    languageList[currentProblem] = newLanguage;
+    languageList[currentProblemIndex] = newLanguage;
   };
 
   const setOneCurrentCode = (newCode: string) => {
-    codeList[currentProblem] = newCode;
+    codeList[currentProblemIndex] = newCode;
   };
 
+  // Returns the most recent submission made for problem of index curr.
   const getSubmission = (curr: number, playerSubmissions: Submission[]) => {
     for (let i = playerSubmissions.length - 1; i >= 0; i -= 1) {
       if (playerSubmissions[i].problemIndex === curr) {
@@ -197,8 +198,8 @@ function GamePage() {
       const codeMap = result;
 
       for (let i = 0; i < result.length; i += 1) {
-        newCodeList.push(result[i][Language.Python]);
-        newLanguageList.push(Language.Python);
+        newCodeList.push(result[i][Language.Java]);
+        newLanguageList.push(Language.Java);
       }
 
       // If previous code and language specified, save those as defaults
@@ -358,9 +359,9 @@ function GamePage() {
     const request = {
       initiator: currentUser!,
       input,
-      code: codeList[currentProblem],
-      language: languageList[currentProblem],
-      problemIndex: currentProblem,
+      code: codeList[currentProblemIndex],
+      language: languageList[currentProblemIndex],
+      problemIndex: currentProblemIndex,
     };
 
     runSolution(roomId, request)
@@ -370,7 +371,7 @@ function GamePage() {
         // Set the 'test' submission type to correctly display result.
         res.submissionType = SubmissionType.Test;
         submissions.push(res);
-        setCurrentSubmission(getSubmission(currentProblem, submissions));
+        setCurrentSubmission(getSubmission(currentProblemIndex, submissions));
         checkSendTestCorrectNotification(res);
       })
       .catch((err) => {
@@ -385,9 +386,9 @@ function GamePage() {
     setError('');
     const request = {
       initiator: currentUser!,
-      code: codeList[currentProblem],
-      language: languageList[currentProblem],
-      problemIndex: currentProblem,
+      code: codeList[currentProblemIndex],
+      language: languageList[currentProblemIndex],
+      problemIndex: currentProblemIndex,
     };
 
     submitSolution(roomId, request)
@@ -397,7 +398,7 @@ function GamePage() {
         // Set the 'submit' submission type to correctly display result.
         res.submissionType = SubmissionType.Submit;
         submissions.push(res);
-        setCurrentSubmission(getSubmission(currentProblem, submissions));
+        setCurrentSubmission(getSubmission(currentProblemIndex, submissions));
         checkSendSolutionCorrectNotification(res);
       })
       .catch((err) => {
@@ -407,19 +408,19 @@ function GamePage() {
   };
 
   const nextProblem = () => {
-    setCurrentProblem((currentProblem + 1) % problems?.length);
-    setCurrentSubmission(getSubmission(currentProblem, submissions));
+    setCurrentProblem((currentProblemIndex + 1) % problems?.length);
+    setCurrentSubmission(getSubmission(currentProblemIndex, submissions));
   };
 
   const previousProblem = () => {
-    let temp = currentProblem - 1;
+    let temp = currentProblemIndex - 1;
 
     if (temp < 0) {
       temp += problems?.length;
     }
 
     setCurrentProblem(temp);
-    setCurrentSubmission(getSubmission(currentProblem, submissions));
+    setCurrentSubmission(getSubmission(currentProblemIndex, submissions));
   };
 
   const displayPlayerLeaderboard = useCallback(() => players.map((player, index) => (
@@ -482,19 +483,19 @@ function GamePage() {
         >
           {/* Problem title/description panel */}
           <OverflowPanel className="display-box-shadow">
-            <ProblemHeaderText>{problems[currentProblem]?.name}</ProblemHeaderText>
-            {problems[currentProblem] ? (
+            <ProblemHeaderText>{problems[currentProblemIndex]?.name}</ProblemHeaderText>
+            {problems[currentProblemIndex] ? (
               <DifficultyDisplayButton
-                difficulty={problems[currentProblem].difficulty!}
+                difficulty={problems[currentProblemIndex].difficulty!}
                 enabled={false}
                 active
               >
-                {displayNameFromDifficulty(problems[currentProblem].difficulty!)}
+                {displayNameFromDifficulty(problems[currentProblemIndex].difficulty!)}
               </DifficultyDisplayButton>
             ) : null}
             <StyledMarkdownEditor
               defaultValue={problems[0]?.description}
-              value={problems[currentProblem]?.description}
+              value={problems[currentProblemIndex]?.description}
               onChange={() => ''}
               readOnly
             />
@@ -523,17 +524,17 @@ function GamePage() {
               <Editor
                 onCodeChange={setOneCurrentCode}
                 onLanguageChange={setOneCurrentLanguage}
-                getCurrentLanguage={() => languageList[currentProblem]}
+                getCurrentLanguage={() => languageList[currentProblemIndex]}
                 defaultCodeMap={defaultCodeList}
-                currentProblem={currentProblem}
-                defaultLanguage={Language.Python}
+                currentProblem={currentProblemIndex}
+                defaultLanguage={Language.Java}
                 defaultCode={null}
               />
             </NoPaddingPanel>
 
             <Panel>
               <Console
-                testCases={problems[currentProblem]?.testCases}
+                testCases={problems[currentProblemIndex]?.testCases}
                 submission={currentSubmission}
                 onRun={runCode}
                 onSubmit={submitCode}

--- a/frontend/src/views/Game.tsx
+++ b/frontend/src/views/Game.tsx
@@ -303,7 +303,7 @@ function GamePage() {
             }
           });
 
-          // If no previous code, proceed as normal with the default Python language
+          // If no previous code, proceed as normal with the default Java language
           if (!matchFound) {
             setDefaultCodeFromProblems(res.problems, []);
           }

--- a/frontend/src/views/Game.tsx
+++ b/frontend/src/views/Game.tsx
@@ -116,7 +116,7 @@ function GamePage() {
   const [players, setPlayers] = useState<Player[]>([]);
   const [gameTimer, setGameTimer] = useState<GameTimer | null>(null);
   const [problems, setProblems] = useState<Problem[]>([]);
-  const [languageList] = useState<Language[]>([Language.Python]);
+  const [languageList, setLanguageList] = useState<Language[]>([Language.Python]);
   const [codeList, setCodeList] = useState<string[]>(['']);
   const [currentSubmission, setCurrentSubmission] = useState<Submission | null>(null);
   const [currentProblem, setCurrentProblem] = useState<number>(0);
@@ -193,10 +193,12 @@ function GamePage() {
     // Get the result of promises and set the default code list.
     Promise.all(promises).then((result) => {
       const newCodeList = [];
+      const newLanguageList = [];
       const codeMap = result;
 
       for (let i = 0; i < result.length; i += 1) {
         newCodeList.push(result[i][Language.Python]);
+        newLanguageList.push(Language.Python);
       }
 
       // If previous code and language specified, save those as defaults
@@ -206,18 +208,19 @@ function GamePage() {
         if (temp != null) {
           newCodeList[i] = temp.code;
           codeMap[i][temp.language as Language] = temp.code;
-          languageList[i] = temp.language as Language;
+          newLanguageList[i] = temp.language as Language;
           setCurrentProblem(i);
         }
       }
 
       // Set this user's current code
       setCodeList(newCodeList);
+      setLanguageList(newLanguageList);
       setDefaultCodeList(codeMap);
     }).catch((err) => {
       setError(err.message);
     });
-  }, [setDefaultCodeList, setCodeList, languageList]);
+  }, [setDefaultCodeList, setCodeList, setLanguageList]);
 
   /**
    * Display the notification as a callback from the notification

--- a/src/main/java/com/codejoust/main/dto/game/SubmissionDto.java
+++ b/src/main/java/com/codejoust/main/dto/game/SubmissionDto.java
@@ -19,6 +19,7 @@ import java.util.List;
 public class SubmissionDto {
     private CodeLanguage language;
     private String code;
+    private int problemIndex;
     private List<SubmissionResultDto> results;
     private Integer numCorrect;
     private Integer numTestCases;

--- a/src/main/java/com/codejoust/main/dto/game/SubmissionRequest.java
+++ b/src/main/java/com/codejoust/main/dto/game/SubmissionRequest.java
@@ -13,5 +13,5 @@ public class SubmissionRequest {
     private String code;
     private String input;
     private UserDto initiator;
-    private int problem = 0;
+    private int problemIndex = 0;
 }

--- a/src/main/java/com/codejoust/main/game_object/Submission.java
+++ b/src/main/java/com/codejoust/main/game_object/Submission.java
@@ -13,6 +13,7 @@ import java.util.List;
 public class Submission {
 
     private PlayerCode playerCode;
+    private int problemIndex;
 
     private List<SubmissionResult> results;
 

--- a/src/main/java/com/codejoust/main/service/GameManagementService.java
+++ b/src/main/java/com/codejoust/main/service/GameManagementService.java
@@ -185,7 +185,7 @@ public class GameManagementService {
             throw new ApiException(GameError.EMPTY_FIELD);
         }
 
-        if (request.getProblem() >= game.getProblems().size() || request.getProblem() < 0) {
+        if (request.getProblemIndex() >= game.getProblems().size() || request.getProblemIndex() < 0) {
             throw new ApiException(GameError.BAD_SETTING);
         }
 
@@ -205,7 +205,7 @@ public class GameManagementService {
             throw new ApiException(GameError.EMPTY_FIELD);
         }
 
-        if (request.getProblem() >= game.getProblems().size() || request.getProblem() < 0) {
+        if (request.getProblemIndex() >= game.getProblems().size() || request.getProblemIndex() < 0) {
             throw new ApiException(GameError.BAD_SETTING);
         }
 

--- a/src/main/java/com/codejoust/main/service/SubmitService.java
+++ b/src/main/java/com/codejoust/main/service/SubmitService.java
@@ -98,15 +98,13 @@ public class SubmitService {
         playerCode.setCode(request.getCode());
         playerCode.setLanguage(request.getLanguage());
 
-        player.setPlayerCode(playerCode);
-
         // Make a call to the tester service
         TesterRequest testerRequest = new TesterRequest();
         testerRequest.setCode(request.getCode());
         testerRequest.setLanguage(request.getLanguage());
 
         // Set the problem with the single provided test case.
-        ProblemDto problemDto = getStrippedProblemDto(game.getProblems().get(request.getProblem()));
+        ProblemDto problemDto = getStrippedProblemDto(game.getProblems().get(request.getProblemIndex()));
 
         /**
          * Provide a temporary output to circumvent output parsing error.
@@ -126,6 +124,8 @@ public class SubmitService {
 
         // Return submission, and no further records necessary for running code.
         Submission submission = getSubmission(testerRequest);
+        submission.setProblemIndex(request.getProblemIndex());
+        player.getSubmissions().add(submission);
         return GameMapper.submissionToDto(submission);
     }
 
@@ -138,18 +138,17 @@ public class SubmitService {
         playerCode.setCode(request.getCode());
         playerCode.setLanguage(request.getLanguage());
 
-        player.setPlayerCode(playerCode);
-
         // Make a call to the tester service
         TesterRequest testerRequest = new TesterRequest();
         testerRequest.setCode(request.getCode());
         testerRequest.setLanguage(request.getLanguage());
 
         // Invariant: Games have at least one problem (else it will fail to create)
-        ProblemDto problemDto = getStrippedProblemDto(game.getProblems().get(request.getProblem()));
+        ProblemDto problemDto = getStrippedProblemDto(game.getProblems().get(request.getProblemIndex()));
         testerRequest.setProblem(problemDto);
 
         Submission submission = getSubmission(testerRequest);
+        submission.setProblemIndex(request.getProblemIndex());
         player.getSubmissions().add(submission);
 
         if (submission.getNumCorrect().equals(submission.getNumTestCases())) {

--- a/src/test/java/com/codejoust/main/api/GameTests.java
+++ b/src/test/java/com/codejoust/main/api/GameTests.java
@@ -341,7 +341,6 @@ public class GameTests {
         // Confirm that running the code does not create a submission.
         assertEquals(1, gameDto.getPlayers().size());
         PlayerDto player = gameDto.getPlayers().get(0);
-        // assertEquals(0, player.getSubmissions().size());
         assertFalse(gameDto.getAllSolved());
     }
     

--- a/src/test/java/com/codejoust/main/api/GameTests.java
+++ b/src/test/java/com/codejoust/main/api/GameTests.java
@@ -341,7 +341,7 @@ public class GameTests {
         // Confirm that running the code does not create a submission.
         assertEquals(1, gameDto.getPlayers().size());
         PlayerDto player = gameDto.getPlayers().get(0);
-        assertEquals(0, player.getSubmissions().size());
+        // assertEquals(0, player.getSubmissions().size());
         assertFalse(gameDto.getAllSolved());
     }
     

--- a/src/test/java/com/codejoust/main/api/GameTests.java
+++ b/src/test/java/com/codejoust/main/api/GameTests.java
@@ -338,9 +338,7 @@ public class GameTests {
         jsonResponse = result.getResponse().getContentAsString();
         GameDto gameDto = UtilityTestMethods.toObjectInstant(jsonResponse, GameDto.class);
 
-        // Confirm that running the code does not create a submission.
         assertEquals(1, gameDto.getPlayers().size());
-        PlayerDto player = gameDto.getPlayers().get(0);
         assertFalse(gameDto.getAllSolved());
     }
     

--- a/src/test/java/com/codejoust/main/mapper/GameMapperTests.java
+++ b/src/test/java/com/codejoust/main/mapper/GameMapperTests.java
@@ -123,8 +123,6 @@ public class GameMapperTests {
         PlayerDto playerDto = gameDto.getPlayers().get(0);
         assertEquals(UserMapper.toDto(user), playerDto.getUser());
         assertEquals(player.getSolved(), playerDto.getSolved());
-        assertEquals(playerCode.getCode(), playerDto.getCode());
-        assertEquals(playerCode.getLanguage(), playerDto.getLanguage());
         assertEquals(1, playerDto.getSubmissions().size());
         assertEquals(player.getColor(), playerDto.getColor());
 


### PR DESCRIPTION
### List of Changes:

- Removed code and language field in PlayerDTO and frontend player object
- Add problem index to submission's object and request's object
- Setting submissions and code on reload now determined by submission object passed from backend to frontend
- renamed a lot of objects into more correct words

### Notes:

I did not remove the code and language fields from the backend player object because there is a LiveUpdateService that uses it. LiveUpdateService is not actually implemented, but could be in the future. Run solutions are now added onto submissions, so that the frontend can display the submissions; to do this, I had to modify a test about submissions; this does not affect the scores. I also had to delete some assertion statements concerning playerCode and playerLanguage in the DTO.

### Screencast and Images:

Loom video of me explaining some stuff:
https://www.loom.com/share/65084292ce65404ba923738bf5a2aad4